### PR TITLE
It's Lua, not LUA.

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,4 +1,4 @@
-# LUA Scripts
+# Lua Scripts
 
 Scripts packaged with Tremulous. This folder will likely fill up with
 not so useful examples.


### PR DESCRIPTION
Lua is not an acronym, it means "moon" in Portuguese: https://en.wiktionary.org/wiki/lua#Portuguese.