### PR TITLE
Fix check for enabling trem 1.1 (alt2) masters

### DIFF
--- a/src/client/cl_main.cpp
+++ b/src/client/cl_main.cpp
@@ -4189,7 +4189,7 @@ static void CL_GlobalServers_f(void)
         // indent
         if (a == 0 && (netAlternateProtocols & NET_DISABLEPRIMPROTO)) continue;
         if (a == 1 && !(netAlternateProtocols & NET_ENABLEALT1PROTO)) continue;
-        if (a == 2 && !(netAlternateProtocols & NET_ENABLEALT1PROTO)) continue;
+        if (a == 2 && !(netAlternateProtocols & NET_ENABLEALT2PROTO)) continue;
 
         // request from all master servers
         if ( masterNum == 0 )

--- a/src/server/sv_main.cpp
+++ b/src/server/sv_main.cpp
@@ -266,7 +266,7 @@ void SV_MasterHeartbeat(const char *message)
 		continue;
 	if(a == 1 && !(netAlternateProtocols & NET_ENABLEALT1PROTO))
 		continue;
-	if(a == 2 && !(netAlternateProtocols & NET_ENABLEALT1PROTO))
+	if(a == 2 && !(netAlternateProtocols & NET_ENABLEALT2PROTO))
 		continue;
 
 	// send to group masters


### PR DESCRIPTION
Fix `net_alternateProtocols 1` causing both GPP and 1.1 masters to be enabled when it's only suppose to enable GPP. code/qcommon/net_ip.cpp already enables GPP and 1.1 separately as intended. I haven't tried to figure out what affect this had.