### PR TITLE
client: add message modes for admin chat and clan chat on 1.1 servers.

### DIFF
--- a/src/client/cl_console.cpp
+++ b/src/client/cl_console.cpp
@@ -103,6 +103,8 @@ Con_MessageMode_f
 void Con_MessageMode_f (void) {
 	chat_playerNum = -1;
 	chat_team = false;
+	chat_admins = false;
+	chat_clans = false;
 	Field_Clear( &chatField );
 	chatField.widthInChars = 30;
 
@@ -117,6 +119,8 @@ Con_MessageMode2_f
 void Con_MessageMode2_f (void) {
 	chat_playerNum = -1;
 	chat_team = true;
+	chat_admins = false;
+	chat_clans = false;
 	Field_Clear( &chatField );
 	chatField.widthInChars = 25;
 	Key_SetCatcher( Key_GetCatcher( ) ^ KEYCATCH_MESSAGE );
@@ -134,6 +138,8 @@ void Con_MessageMode3_f (void) {
 		return;
 	}
 	chat_team = false;
+	chat_admins = false;
+	chat_clans = false;
 	Field_Clear( &chatField );
 	chatField.widthInChars = 30;
 	Key_SetCatcher( Key_GetCatcher( ) ^ KEYCATCH_MESSAGE );
@@ -151,8 +157,42 @@ void Con_MessageMode4_f (void) {
 		return;
 	}
 	chat_team = false;
+	chat_admins = false;
+	chat_clans = false;
 	Field_Clear( &chatField );
 	chatField.widthInChars = 30;
+	Key_SetCatcher( Key_GetCatcher( ) ^ KEYCATCH_MESSAGE );
+}
+
+/*
+================
+Con_MessageMode5_f
+================
+*/
+void Con_MessageMode5_f (void) {
+	int i;
+	chat_playerNum = -1;
+	chat_team = false;
+	chat_admins = true;
+	chat_clans = false;
+	Field_Clear( &chatField );
+	chatField.widthInChars = 25;
+	Key_SetCatcher( Key_GetCatcher( ) ^ KEYCATCH_MESSAGE );
+}
+
+/*
+================
+Con_MessageMode6_f
+================
+*/
+void Con_MessageMode6_f (void) {
+	int i;
+	chat_playerNum = -1;
+	chat_team = false;
+	chat_admins = false;
+	chat_clans = true;
+	Field_Clear( &chatField );
+	chatField.widthInChars = 25;
 	Key_SetCatcher( Key_GetCatcher( ) ^ KEYCATCH_MESSAGE );
 }
 
@@ -361,6 +401,10 @@ void Con_MessageModesInit(void) {
 			Cmd_AddCommand ("messagemode3", Con_MessageMode3_f);
 		if( !Cmd_CommadExists( "messagemode4" ) )
 			Cmd_AddCommand ("messagemode4", Con_MessageMode4_f);
+		if( !Cmd_CommadExists( "messagemode5" ) )
+			Cmd_AddCommand ("messagemode5", Con_MessageMode5_f);
+		if( !Cmd_CommadExists( "messagemode6" ) )
+			Cmd_AddCommand ("messagemode6", Con_MessageMode6_f);
 	} else
 	{
 		// remove the client side message modes for non-1.1 servers
@@ -368,6 +412,8 @@ void Con_MessageModesInit(void) {
 		Cmd_RemoveCommand("messagemode2");
 		Cmd_RemoveCommand("messagemode3");
 		Cmd_RemoveCommand("messagemode4");
+		Cmd_RemoveCommand("messagemode5");
+		Cmd_RemoveCommand("messagemode6");
 	}
 }
 
@@ -401,6 +447,8 @@ void Con_Init (void) {
 		Cmd_AddCommand ("messagemode2", Con_MessageMode2_f);
 		Cmd_AddCommand ("messagemode3", Con_MessageMode3_f);
 		Cmd_AddCommand ("messagemode4", Con_MessageMode4_f);
+		Cmd_AddCommand ("messagemode5", Con_MessageMode5_f);
+		Cmd_AddCommand ("messagemode6", Con_MessageMode6_f);
 	}
 
 	Cmd_AddCommand ("toggleconsole", Con_ToggleConsole_f);
@@ -722,14 +770,23 @@ void Con_DrawConsole( void ) {
 
 		if( chatField.buffer[0] == '/' ||
 				chatField.buffer[0] == '\\' )
-			{
-				SCR_DrawBigString( 8, 232, "Command:", 1.0f, qfalse );
-				skip = 10;
-			}
-
+		{
+			SCR_DrawBigString( 8, 232, "Command:", 1.0f, qfalse );
+			skip = 10;
+		}
     else if( chat_team )
     {
       SCR_DrawBigString( 8, 232, "Team Say:", 1.0f, qfalse );
+      skip = 11;
+    }
+    else if( chat_admins )
+    {
+      SCR_DrawBigString( 8, 232, "Admin Say:", 1.0f, qfalse );
+      skip = 11;
+    }
+    else if( chat_clans )
+    {
+      SCR_DrawBigString( 8, 232, "Clan Say:", 1.0f, qfalse );
       skip = 11;
     }
     else

--- a/src/client/cl_keys.cpp
+++ b/src/client/cl_keys.cpp
@@ -815,7 +815,7 @@ static void Message_Key( int key ) {
 				} else {
 					//string isnt long enough
 					Com_Printf ( 
-						"^3Error:your clantag has to be Between 3 and 10 chars long. current value is:^7 %s^7\n",
+						"^3Error:your cl_clantag has to be Between 3 and 10 chars long. current value is:^7 %s^7\n",
 						clantagDecolored );
 					return;
 				}

--- a/src/client/cl_keys.cpp
+++ b/src/client/cl_keys.cpp
@@ -39,6 +39,8 @@ field_t g_consoleField;
 
 field_t chatField;
 bool chat_team;
+bool chat_admins;
+bool chat_clans;
 int chat_playerNum;
 
 bool key_overstrikeMode;
@@ -793,6 +795,30 @@ static void Message_Key( int key ) {
 				Com_sprintf( buffer, sizeof( buffer ),
 				             "say_team \"%s\"\n",
 										 chatField.buffer );
+			}
+			else if (chat_admins) {
+				Com_sprintf( buffer, sizeof( buffer ), 
+										 "a \"%s\"\n",
+										 chatField.buffer );
+			}
+			else if (chat_clans) {
+				char clantagDecolored[ 32 ];
+
+				Q_strncpyz( clantagDecolored, cl_clantag->string,
+										sizeof(clantagDecolored) );
+				Q_CleanStr( clantagDecolored );
+
+				if( strlen(clantagDecolored) > 2 && strlen(clantagDecolored) < 11 ) {
+					Com_sprintf( buffer, sizeof( buffer ),
+											 "m \"%s\" \"%s\"\n", clantagDecolored,
+											 chatField.buffer );
+				} else {
+					//string isnt long enough
+					Com_Printf ( 
+						"^3Error:your clantag has to be Between 3 and 10 chars long. current value is:^7 %s^7\n",
+						clantagDecolored );
+					return;
+				}
 			}
 			else {
 				Com_sprintf( buffer, sizeof( buffer ),

--- a/src/client/cl_main.cpp
+++ b/src/client/cl_main.cpp
@@ -125,6 +125,8 @@ cvar_t *cl_lanForcePackets;
 
 cvar_t *cl_guidServerUniq;
 
+cvar_t *cl_clantag;
+
 cvar_t *cl_consoleKeys;
 
 cvar_t *cl_rate;
@@ -4919,6 +4921,8 @@ void CL_Init(void)
 
     // ~ and `, as keys and characters
     cl_consoleKeys = Cvar_Get("cl_consoleKeys", "~ ` 0x7e 0x60", CVAR_ARCHIVE);
+
+    cl_clantag = Cvar_Get ("cl_clantag", "", CVAR_ARCHIVE);
 
     // userinfo
     Cvar_Get("name", "UnnamedPlayer", CVAR_USERINFO | CVAR_ARCHIVE);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -504,6 +504,8 @@ extern cvar_t *cl_inGameVideo;
 extern cvar_t *cl_lanForcePackets;
 extern cvar_t *cl_autoRecordDemo;
 
+extern cvar_t *cl_clantag;
+
 extern cvar_t *cl_consoleKeys;
 
 #ifdef USE_MUMBLE

--- a/src/client/keys.h
+++ b/src/client/keys.h
@@ -48,6 +48,8 @@ extern field_t g_consoleField;
 extern field_t chatField;
 extern int anykeydown;
 extern bool chat_team;
+extern bool chat_admins;
+extern bool chat_clans;
 extern int chat_playerNum;
 
 void Key_WriteBindings(fileHandle_t f);


### PR DESCRIPTION
For the Tremulous 1.1 protocol, `messagemode5` opens up a say menu for sending messages to admins, and `messagemode6` opens up a say menu for sending mass private messages to everyone on the server that has the clan tag specified by the cvar cl_clantag in their name.