### PR TITLE
cg_particles: do not return previous particle pointer if maximum is hit

### DIFF
--- a/src/cgame/cg_particles.c
+++ b/src/cgame/cg_particles.c
@@ -325,11 +325,14 @@ static particle_t *CG_SpawnNewParticle( baseParticle_t *bp, particleEjector_t *p
         }
       }
 
-      break;
+      return p;
     }
   }
 
-  return p;
+  if( cg_debugParticles.integer >= 1 )
+    CG_Printf( "MAX_PARTICLES\n" );
+
+  return NULL;
 }
 
 
@@ -447,11 +450,14 @@ static particleEjector_t *CG_SpawnNewParticleEjector( baseParticleEjector_t *bpe
       if( cg_debugParticles.integer >= 1 )
         CG_Printf( "PE %s created\n", ps->class->name );
 
-      break;
+      return pe;
     }
   }
 
-  return pe;
+  if( cg_debugParticles.integer >= 1 )
+    CG_Printf( "MAX_PARTICLE_EJECTORS\n" );
+
+  return NULL;
 }
 
 
@@ -497,11 +503,14 @@ particleSystem_t *CG_SpawnNewParticleSystem( qhandle_t psHandle )
       if( cg_debugParticles.integer >= 1 )
         CG_Printf( "PS %s created\n", bps->name );
 
-      break;
+      return ps;
     }
   }
 
-  return ps;
+  if( cg_debugParticles.integer >= 1 )
+    CG_Printf( "MAX_PARTICLE_SYSTEMS\n" );
+
+  return NULL;
 }
 
 /*


### PR DESCRIPTION
See PR on upstream:

- https://github.com/darklegion/tremulous/pull/24

---

Fix random substitution of particles.

I noticed there was no error message for `MAX_PARTICLE_SYSTEMS` being hit. I noticed there was an error message for `MAX_TRAIL_SYSTEMS` being hit.

So I wanted to add such error message to debug the random substitution of particles.

So I decided to copy-paste the `MAX_TRAIL_SYSTEMS` hit message and implement it for `MAX_PARTICLE_SYSTEMS` the cargo cult way.

So I discovered the particle code was not only not printing anything when `MAX_PARTICLE_SYSTEMS` was hit, but was also returning the particle system anyway, the previous one before hitting `MAX_PARTICLE_SYSTEMS`.

Then I discovered a similar unexpected return of reused pointer was also done when `MAX_PARTICLES` and `MAX_PARTICLE_EJECTORS` were hit.

- Do not return previous particle if `MAX_PARTICLES` is hit
- Do not return previous particle system if `MAX_PARTICLE_SYSTEMS` is hit
- Do not return previous particle ejector if `MAX_PARTICLE_EJECTORS` is hit

This is a port of a patch from Unvanquished: https://unvanquished.net